### PR TITLE
⚡Remove new TimeOnly allocation for each DateOnly SetValue call.

### DIFF
--- a/Dapper.Handlers/SqlDateOnlyTypeHandler.cs
+++ b/Dapper.Handlers/SqlDateOnlyTypeHandler.cs
@@ -5,6 +5,7 @@ namespace kp.Dapper.Handlers;
 
 public class SqlDateOnlyTypeHandler : SqlMapper.TypeHandler<DateOnly>
 {
-    public override void SetValue(IDbDataParameter parameter, DateOnly date) => parameter.Value = date.ToDateTime(new TimeOnly(0, 0));
+    private static readonly TimeOnly _midnight = new(0, 0);
+    public override void SetValue(IDbDataParameter parameter, DateOnly date) => parameter.Value = date.ToDateTime(_midnight);
     public override DateOnly Parse(object value) => DateOnly.FromDateTime((DateTime)value);
 }


### PR DESCRIPTION
Little memory improvement, thus in turn less pressure on GC, as the type mapper can be called 1,000s of times in the lifetime of the application.